### PR TITLE
Ability to infinite-play shorter videos with or without notification and without disabling functionality for longer videos.

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -17,4 +17,5 @@
     <string id="30016">Display random unwatched notification</string>
     <string id="30017">Automatically play short videos (no notification)</string>
     <string id="30018">Maximum length for automatic short video play (in minutes)</string>
+    <string id="30019">Show on-screen notification during short video autoplay</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
     <string id="30001">The number of seconds before the end to show the notification</string>
     <string id="30002">Log Level:</string>
@@ -15,4 +15,6 @@
     <string id="30014">Disable NextUp (restart required)</string>
     <string id="30015">The number of seconds before displaying random unwatched notification</string>
     <string id="30016">Display random unwatched notification</string>
+    <string id="30017">Automatically play short videos (no notification)</string>
+    <string id="30018">Maximum length for automatic short video play (in minutes)</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -15,7 +15,7 @@
     <string id="30014">Disable NextUp (restart required)</string>
     <string id="30015">The number of seconds before displaying random unwatched notification</string>
     <string id="30016">Display random unwatched notification</string>
-    <string id="30017">Automatically play short videos (no notification)</string>
+    <string id="30017">Automatically play short videos</string>
     <string id="30018">Maximum length for automatic short video play (in minutes)</string>
     <string id="30019">Show on-screen notification during short video autoplay</string>
 </strings>

--- a/resources/lib/Player.py
+++ b/resources/lib/Player.py
@@ -283,6 +283,7 @@ class Player(xbmc.Player):
                 currentshowtitle = result["result"]["item"]["showtitle"]
                 tvshowid = result["result"]["item"]["tvshowid"]
                 shortplayMode = addonSettings.getSetting("shortPlayMode")
+                shortplayNotification= addonSettings.getSetting("shortPlayNotification")
                 shortplayLength = int(addonSettings.getSetting("shortPlayLength") * 60)
 
 
@@ -348,6 +349,9 @@ class Player(xbmc.Player):
                         self.logMsg("played in a row %s" % str(self.playedinarow), 2)
                         if shortplayLength >= int(totalTime) and shortplayMode == "true":
                             self.logMsg("autoplaying short video - %s" % str(self.playedinarow), 2)
+                            if shortplayNotification == "true":
+                                self.logMsg("showing notification for short videos")
+                                nextUpPage.show()
                         elif int(self.playedinarow) <= int(playedinarownumber):
                             self.logMsg(
                                 "showing next up page as played in a row is %s" % str(self.playedinarow), 2)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,6 +13,6 @@
         <setting id="logLevel" type="enum" label="30002" values="None|Info|Debug" default="0"/>
         <setting id="shortPlayMode" type="bool" label="30017" default="false" visible="true" enable="true"/>
         <setting id="shortPlayLength" type="number" label="30018" default="10" visible="true" enable="true"/>
-        <setting id="shortPlayNotification" type="bool" label="30019" default="false" visible="true" enable="true"/>
+        <setting id="shortPlayNotification" type="bool" label="30019" default="true" visible="true" enable="true"/>
     </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,11 +7,12 @@
         <setting id="includeWatched" type="bool" label="30013" default="false" visible="true" enable="true"/>
         <setting id="displayRandomUnwatched" type="bool" label="30016" default="false" visible="true" enable="true"/>
         <setting id="displayRandomUnwatchedTime" type="number" label="30015" default="600" visible="eq(-1,true)" enable="true"/>
-        <setting id="shortPlayMode" type="bool" label="30017" default="false" visible="true" enable="true"/>
-        <setting id="shortPlayLength" type="number" label="30018" default="10" visible="true" enable="true"/>
     </category>
     <category label="30004">
         <setting id="disableNextUp" type="bool" label="30014" default="false" visible="true" enable="true"/>
         <setting id="logLevel" type="enum" label="30002" values="None|Info|Debug" default="0"/>
+        <setting id="shortPlayMode" type="bool" label="30017" default="false" visible="true" enable="true"/>
+        <setting id="shortPlayLength" type="number" label="30018" default="10" visible="true" enable="true"/>
+        <setting id="shortPlayNotification" type="bool" label="30019" default="false" visible="true" enable="true"/>
     </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,6 +7,8 @@
         <setting id="includeWatched" type="bool" label="30013" default="false" visible="true" enable="true"/>
         <setting id="displayRandomUnwatched" type="bool" label="30016" default="false" visible="true" enable="true"/>
         <setting id="displayRandomUnwatchedTime" type="number" label="30015" default="600" visible="eq(-1,true)" enable="true"/>
+        <setting id="shortPlayMode" type="bool" label="30017" default="false" visible="true" enable="true"/>
+        <setting id="shortPlayLength" type="number" label="30018" default="10" visible="true" enable="true"/>
     </category>
     <category label="30004">
         <setting id="disableNextUp" type="bool" label="30014" default="false" visible="true" enable="true"/>


### PR DESCRIPTION
I'm kind of a newbie to python (I'm a mediocre PHP coder at best), but while I love NextUp, I also have a daughter who loves watching kids shows with short episode lengths ad nauseum. So I added some lines to the player, settings and strings to allow a user-definable maximum episode length for automatic, infinite play, with or without notification. Basically, "Number of episodes before still watching query" gets ignored for shorter videos. It can also apply to short interstitials (short interviews, special webisodes, etc) for regular TV series, without interrupting full-length video "still watching" settings.
