### PR TITLE
library call fix

### DIFF
--- a/resources/lib/NextUpInfo.py
+++ b/resources/lib/NextUpInfo.py
@@ -39,7 +39,7 @@ class NextUpInfo(xbmcgui.WindowXMLDialog):
 
         # set the dialog data
         self.getControl(3000).setLabel(name)
-        self.getControl(3001).setText(overview)
+        self.getControl(3001).setLabel(overview)
         self.getControl(3002).setLabel(episodeInfo)
         self.getControl(3004).setLabel(info)
 


### PR DESCRIPTION
Was customizing my skin to display the thumb of the next episode and faced "controll xy not defined" issues, so I put them all into the xml which caused an error - which as I assume anyone would face who tries to use control 3001 (and maybe 4006).

The error:
'xbmcgui.ControlLabel' object has no attribute 'setText'
