### PR TITLE
fix image on nextup for streaming media from netflix and amazon plugin

### DIFF
--- a/resources/skins/default/1080i/script-nextup-notification-NextUpInfo.xml
+++ b/resources/skins/default/1080i/script-nextup-notification-NextUpInfo.xml
@@ -13,12 +13,11 @@
 					<animation effect="fade" start="100" end="97" time="200" condition="true">Conditional</animation>
 					<texture border="5" colordiffuse="ff000000">box.png</texture>
 				</control>
-				<control type="image" description="fanart">
+				<control type="image" id="3005" description="fanart">
 					<width>100%</width>
 					<height>100%</height>
 					<fadetime>350</fadetime>
 					<aspectratio scalediffuse="false">scale</aspectratio>
-					<texture>$INFO[Player.Art(fanart)]</texture>
 				</control>
 				<control type="image">
 					<left>0</left>


### PR DESCRIPTION
I have tried many things to solve the problem on the addon side (netflix/amazon) but there it is no way to set the image in palyer/listitem a way that your script will grab it. It was always black (not present / empty string). So i have checked a little bit deeper your code and the clean way is to set the image inside the xml via the id which will work for normal media and streaming media.

PS: some time ago i had opened a bug report you will remeber - the first problem was that i am using a skin which includes a custom nextup page and i didn't noticed it so i tried to find a solution on a wrong base and changes wasn't shown :-( You will imagine i was using a lot of time for nothing *lol*

With commit:
![screenshot002](https://user-images.githubusercontent.com/761728/32253256-347fc968-be9a-11e7-8590-e69ef2fd4b3b.png)

Old without the commit:
![screenshot003](https://user-images.githubusercontent.com/761728/32253273-4630f1dc-be9a-11e7-8932-c17e985ee274.png)
