### PR TITLE
failsave landscape

### DIFF
--- a/resources/lib/NextUpInfo.py
+++ b/resources/lib/NextUpInfo.py
@@ -25,6 +25,10 @@ class NextUpInfo(xbmcgui.WindowXMLDialog):
         clearartimage = self.item['art'].get('tvshow.clearart', '')
         landscapeimage = self.item['art'].get('tvshow.landscape', '')
         fanartimage = self.item['art'].get('tvshow.fanart', '')
+        # make sure landscape is filled - by default landscape contains a smaller fanart image with the tvshow banner
+        # but in many cases it is not available - so replace it with fanart
+        if landscapeimage.strip() == "":
+            landscapeimage = self.item['art'].get('tvshow.fanart', '')
         overview = self.item['plot']
         tvshowtitle = self.item['showtitle']
         name = self.item['title']


### PR DESCRIPTION
For example guilouz with his estuary mod v2 ( i think it is really often used) has a customized nextup page and hi is now using id 3010 (landscape image). I noticed landscape image is often missing from scapers and the only difference between landscape and fanart (id 3005) is a smaller size and it contains the tvshow logo. So lets do a failsave and set landscape to fanart if landscape is not available. Better than missing image in nextup dialog.