### PR TITLE
Init prepare for skip intro extension

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -28,4 +28,5 @@
     <string id="30027">Enable SkipIntro by DB Request</string>
     <string id="30028">MySQL-DB-Server</string>
     <string id="30029">Enable SkipIntro triggered by other addons</string>
+    <string id="30030">Enable SkipIntro without pause</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -24,4 +24,8 @@
     <string id="30023">Show plot on postplay screen</string>
     <string id="30024">Still There?</string>
     <string id="30025">Show preview before postplay screen</string>
+    <string id="30026">SkipIntro</string>
+    <string id="30027">Enable SkipIntro by DB Request</string>
+    <string id="30028">MySQL-DB-Server</string>
+    <string id="30029">Enable SkipIntro triggered by other addons</string>
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -24,4 +24,8 @@
     <string id="30023">Zeige Beschreibung auf Übersichtsbildschirm</string>
     <string id="30024">Noch am schauen?</string>
     <string id="30025">Zeige Benachrichtigung vor Übersichtsbildschirm</string>
+    <string id="30026">SkipIntro</string>
+    <string id="30027">Aktiviere SkipIntro durch DB-Abfrage</string>
+    <string id="30028">MySQL-DB-Server</string>
+    <string id="30029">Aktiviere SkipIntro ausgelößt durch andere Addons</string>
 </strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -28,4 +28,5 @@
     <string id="30027">Aktiviere SkipIntro durch DB-Abfrage</string>
     <string id="30028">MySQL-DB-Server</string>
     <string id="30029">Aktiviere SkipIntro ausgelößt durch andere Addons</string>
+    <string id="30030">Aktiviere SkipIntro ohne Pause</string>
 </strings>

--- a/resources/lib/Player.py
+++ b/resources/lib/Player.py
@@ -137,10 +137,10 @@ class Player(xbmc.Player):
                     WINDOW.setProperty("NextUpNotification.introStart", str(introStart))
                     WINDOW.setProperty("NextUpNotification.introLenght", str(introLenght))
 
-                    if (int(playTime) < (introStart+introLenght)):
+                    if ((introStart != '') or (introLenght != '')):
                         WINDOW.setProperty("NextUpNotification.Unskipped", "True")
                         dlg = xbmcgui.Dialog()
-                        dlg.notification("Nextup Service Notification", 'Skipping Intro Set!', xbmcgui.NOTIFICATION_INFO, 5000)
+                        dlg.notification("Nextup Service Notification", 'Skipping Intro Prepared!', xbmcgui.NOTIFICATION_INFO, 2000)
 
             elif itemtype == "movie":
                 WINDOW.setProperty("NextUpNotification.NowPlaying.Type", itemtype)

--- a/resources/lib/Player.py
+++ b/resources/lib/Player.py
@@ -139,6 +139,8 @@ class Player(xbmc.Player):
 
                     if (int(playTime) < (introStart+introLenght)):
                         WINDOW.setProperty("NextUpNotification.Unskipped", "True")
+                        dlg = xbmcgui.Dialog()
+                        dlg.notification("Nextup Service Notification", 'Skipping Intro Set!', xbmcgui.NOTIFICATION_INFO, 5000)
 
             elif itemtype == "movie":
                 WINDOW.setProperty("NextUpNotification.NowPlaying.Type", itemtype)
@@ -608,3 +610,4 @@ class Player(xbmc.Player):
                         xbmc.executeJSONRPC(
                             '{ "jsonrpc": "2.0", "id": 0, "method": "Player.Open", '
                             '"params": { "item": {"episodeid": ' + str(episode["episodeid"]) + '} } }')
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -18,4 +18,9 @@
         <setting id="shortPlayLength" type="number" label="30018" default="10" visible="true" enable="true"/>
         <setting id="shortPlayNotification" type="bool" label="30019" default="true" visible="true" enable="true"/>
     </category>
+    <category label="30026">
+        <setting id="enableNextUpSkip" type="bool" label="30027" default="false" visible="true" enable="true"/>
+        <setting id="SkipDBServer" type="text" label="30028" default="https://www.yourwebserver.com:port" visible="eq(-1,true)" enable="true"/>
+        <setting id="enableNextUpSkip3rdP" type="bool" label="30029" default="false" visible="true" enable="true"/>
+    </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -22,5 +22,6 @@
         <setting id="enableNextUpSkip" type="bool" label="30027" default="false" visible="true" enable="true"/>
         <setting id="SkipDBServer" type="text" label="30028" default="https://www.yourwebserver.com:port" visible="eq(-1,true)" enable="true"/>
         <setting id="enableNextUpSkip3rdP" type="bool" label="30029" default="false" visible="true" enable="true"/>
+        <setting id="enableNextUpSkipNoPause" type="bool" label="30030" default="false" visible="true" enable="true"/>
     </category>
 </settings>

--- a/service.py
+++ b/service.py
@@ -65,8 +65,8 @@ class Service():
         lastUnwatchedFile = None
 
         while not monitor.abortRequested():
-            # check every 5 sec
-            if monitor.waitForAbort(5):
+            # check every 1 sec
+            if monitor.waitForAbort(1):
                 # Abort was requested while waiting. We should exit
                 break
             if xbmc.Player().isPlaying():

--- a/service.py
+++ b/service.py
@@ -82,6 +82,7 @@ class Service():
                     nextUpDisabled = addonSettings.getSetting("disableNextUp") == "true"
                     nextUpSkipEnabled = addonSettings.getSetting("enableNextUpSkip") == "true"
                     nextUpSkipEnabled3rdP = addonSettings.getSetting("enableNextUpSkip3rdP") == "true"
+                    nextUpSkipEnabledNoPause = addonSettings.getSetting("enableNextUpSkipNoPause") == "true"
                     randomunwatchedtime = addonSettings.getSetting("displayRandomUnwatchedTime")
                     displayrandomunwatched = addonSettings.getSetting("displayRandomUnwatched") == "true"
                     showpostplay = addonSettings.getSetting("showPostPlay") == "true"
@@ -93,12 +94,16 @@ class Service():
                         if ((playTime >= introStart) and (playTime < (playTime+introLenght))):
                             dlg = xbmcgui.Dialog()
                             dlg.notification("Nextup Service Notification", 'Skipping Intro...', xbmcgui.NOTIFICATION_INFO, 5000)
-                            xbmc.Player().pause()
-                            time.sleep(1) # give kodi the chance to execute
-                            xbmc.Player().seekTime(introStart+introLenght)
-                            time.sleep(1) # give kodi the chance to execute
-                            xbmc.Player().pause()# unpause playback at seek position
-                            xbmcgui.Window(10000).clearProperty("NextUpNotification.Unskipped")
+			    if nextUpSkipEnabledNoPause == "true":
+				xbmc.Player().seekTime(introStart+introLenght)
+				xbmcgui.Window(10000).clearProperty("NextUpNotification.Unskipped")
+			    else:
+				xbmc.Player().pause()
+				time.sleep(1) # give kodi the chance to execute
+				xbmc.Player().seekTime(introStart+introLenght)
+				time.sleep(1) # give kodi the chance to execute
+				xbmc.Player().pause()# unpause playback at seek position
+				xbmcgui.Window(10000).clearProperty("NextUpNotification.Unskipped")
 
                     if xbmcgui.Window(10000).getProperty("PseudoTVRunning") != "True" and not nextUpDisabled:
 


### PR DESCRIPTION
Last days i have done some work to make it possible to skip intros by timecodes (position / lenght).
I created a backend in php and mysql which can be hosted on a server and can deliver the timecodes by request of the addon. The database itselve can be managed by a webinterface to insert / update / delete entries (screenshot). After some more testing i will publich it next days, too.
So everyone can create a skipintro database for his own private stuff or possible a big database for more users.
Additional the skip option can be used by other addons if enabled in settings (the own server with db is optional!). So 3rd parity addons like amazon, netflix etc, can use the option, too :-)
![index](https://user-images.githubusercontent.com/761728/33412544-396f794c-d58c-11e7-8e1f-9739bc282ffd.png)
